### PR TITLE
Github issue#901, Switch topcoder app to member service search URLs instead of internal-api (lambda)

### DIFF
--- a/src/actions/loadMemberSearch.spec.js
+++ b/src/actions/loadMemberSearch.spec.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk'
 import nock from 'nock'
 import { initialState } from '../reducers/memberSearch.js'
 import { initialState as searchTermInitialState } from '../reducers/searchTerm.js'
-import { INTERNAL_API } from '../config/constants.js'
+import { V3_API } from '../config/constants.js'
 
 import {
   loadMemberSearch, checkIfSearchTermIsATag,
@@ -35,7 +35,7 @@ describe('loadMemberSearch Actions:', () => {
   const topMemberResults = ['topMember1', 'topMember2']
 
   const mockSuccessfulTagAPICall = () => {
-    nock(INTERNAL_API)
+    nock(V3_API)
       .get(/\/tags/)
       .reply(200, { result: {
         content: [mockTag]
@@ -43,7 +43,7 @@ describe('loadMemberSearch Actions:', () => {
   }
 
   const mockSuccessfulUsernameMatchesAPICall = () => {
-    nock(INTERNAL_API)
+    nock(V3_API)
       .get(/\/members\/_search/)
       .reply(200, { result: {
         content: usernameMatchResults,
@@ -52,7 +52,7 @@ describe('loadMemberSearch Actions:', () => {
   }
 
   const mockSuccessfulTopMembersAPICall = () => {
-    nock(INTERNAL_API)
+    nock(V3_API)
       .get(/\/leaderboards\/\?filter/)
       .reply(200, { result: { content: topMemberResults } })
   }
@@ -71,7 +71,7 @@ describe('loadMemberSearch Actions:', () => {
         }
       })
 
-      nock(INTERNAL_API)
+      nock(V3_API)
         .get(/\/tags/)
         .reply(200, { result: { content: [] }})
 
@@ -166,7 +166,7 @@ describe('loadMemberSearch Actions:', () => {
     it('calls memberSearchFailure when the request fails', () => {
       const store = mockStore({ memberSearch: initialState })
 
-      nock(INTERNAL_API)
+      nock(V3_API)
         .get(/\/tags/)
         .reply(500, 'failure')
 
@@ -209,7 +209,7 @@ describe('loadMemberSearch Actions:', () => {
     it(`dispatches ${MEMBER_SEARCH_FAILURE} when the request fails`, () => {
       const store = mockStore({ memberSearch: initialState })
 
-      nock(INTERNAL_API)
+      nock(V3_API)
         .get(/\/members\/_search/)
         .reply(500, 'failure')
 
@@ -247,7 +247,7 @@ describe('loadMemberSearch Actions:', () => {
     it('calls memberSearchFailure when the request fails', () => {
       const store = mockStore({ memberSearch: initialState })
 
-      nock(INTERNAL_API)
+      nock(V3_API)
         .get(/\/leaderboards.*/)
         .reply(500, 'failure')
 

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -21,12 +21,11 @@ export const TOP_MEMBER_SEARCH_SUCCESS = 'TOP_MEMBER_SEARCH_SUCCESS'
 
 export const DOMAIN = process.env.domain || 'topcoder.com'
 
-// FIXME: Change to process.env.INTERNAL_API after added to webpack
-export const INTERNAL_API = `https://internal-api.${DOMAIN}/v3`
+export const V3_API = `https://api.${DOMAIN}/v3`
 
-export const memberSearchTagUrl = `${INTERNAL_API}/tags/`
+export const memberSearchTagUrl = `${V3_API}/tags/`
 
-export const memberSearchUrl = `${INTERNAL_API}/members/_search/`
+export const memberSearchUrl = `${V3_API}/members/_search/`
 export const challengeSearchUrl = 'https://ol348e2ya5.execute-api.us-east-1.amazonaws.com/dev'
 
-export const leaderboardUrl = `${INTERNAL_API}/leaderboards/`
+export const leaderboardUrl = `${V3_API}/leaderboards/`

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -278,5 +278,5 @@ export function mapTagToLeaderboardType(tagDomain) {
     SKILLS: 'MEMBER_SKILL'
   }
 
-  return tagToLeaderboardTypeMap[tagDomain]
+  return tagDomain ? tagToLeaderboardTypeMap[tagDomain.toUpperCase()] : null
 }


### PR DESCRIPTION
-- Replaced all internal api urls with standard api urls and tested the search functionality on local.

@parthshah fyi